### PR TITLE
books_tableのauthor_idの型を修正し、migrateも完了

### DIFF
--- a/database/migrations/2024_02_22_140225_books_table.php
+++ b/database/migrations/2024_02_22_140225_books_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
         Schema::create('books', function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');
-            $table->int('author_id');
+            $table->integer('author_id');
         });
     }
 


### PR DESCRIPTION
migrateしたらエラーが出たのでエラーメッセージを見たら、Blueprintクラスにintメソッドがなかったためだった。型をintegerに修正したらmigrateが実行された。